### PR TITLE
Updates for IP Messaging 0.14.x

### DIFF
--- a/IPMQuickstart/IPMQuickstart-Bridging-Header.h
+++ b/IPMQuickstart/IPMQuickstart-Bridging-Header.h
@@ -9,6 +9,7 @@
 #ifndef IPMQuickstart_Bridging_Header_h
 #define IPMQuickstart_Bridging_Header_h
 
+#import <TwilioCommon/TwilioCommon.h>
 #import <TwilioIPMessagingClient/TwilioIPMessagingClient.h>
 
 #endif /* IPMQuickstart_Bridging_Header_h */

--- a/IPMQuickstart/SwiftyJSON.swift
+++ b/IPMQuickstart/SwiftyJSON.swift
@@ -396,7 +396,7 @@ public struct JSONGenerator : GeneratorType {
     switch self.type {
     case .Array:
       if let o = self.arrayGenerate?.next() {
-        return (String(self.arrayIndex++), JSON(o))
+        return (String(self.arrayIndex += 1), JSON(o))
       } else {
         return nil
       }

--- a/Podfile
+++ b/Podfile
@@ -1,4 +1,6 @@
-source 'https://github.com/CocoaPods/Specs.git'
+source 'https://github.com/CocoaPods/Specs'
+source 'https://github.com/twilio/cocoapod-specs'
 
-pod 'TwilioIPMessagingClient', :podspec => 'https://media.twiliocdn.com/sdk/rtc/ios/ip-messaging/v0.13/TwilioIPMessagingClient.podspec'
-pod 'TwilioCommon', :podspec => 'https://media.twiliocdn.com/sdk/rtc/ios/common/v0.1/TwilioCommon.podspec'
+target 'IPMQuickstart' do
+  pod 'TwilioIPMessagingClient', '~> 0.14.0'
+end


### PR DESCRIPTION
- Updated to explicitly import TwilioCommon as in a future version, TwilioIPMessagingClient will not implicitly do so
- Adopt new client initialization strategy for IP Messaging 0.14.x
- Updated Podfile to reflect current integration strategy
- s/++/+=1/ for Swift 3
- Updated Selector calls to resolve compile warnings
